### PR TITLE
Add explicit whitelist for MIME-types that can be previewed on Safari

### DIFF
--- a/components/file-explorer/viewers/base.tsx
+++ b/components/file-explorer/viewers/base.tsx
@@ -3,6 +3,7 @@ import { ImageViewer } from "@/components/file-explorer/viewers/image"
 import { TextViewer } from "@/components/file-explorer/viewers/text"
 import { PreviewNotSupported } from "@/components/file-explorer/viewers/not-supported"
 import { Eye } from "lucide-react"
+import { useMemo } from "react"
 
 export interface ViewerProps {
     data?: Blob
@@ -24,7 +25,13 @@ const IMAGE_TYPES = [
 ]
 const TEXT_TYPES = ["text/plain", "application/json"]
 
+const SAFARI_SUPPORTED_OBJECTS_TYPES = ["text/html"]
+
 export function BaseViewer(props: ViewerProps) {
+    const usesSafari = useMemo(() => {
+        return navigator.userAgent.toLowerCase().includes("safari")
+    }, [])
+
     if (!props.data)
         return (
             <div className="grow flex justify-center items-center">
@@ -42,7 +49,9 @@ export function BaseViewer(props: ViewerProps) {
         return <ImageViewer {...props} />
     } else if (TEXT_TYPES.includes(props.data.type)) {
         return <TextViewer {...props} />
-    } else {
+    } else if (!usesSafari || SAFARI_SUPPORTED_OBJECTS_TYPES.includes(props.data.type)) {
         return <ObjectViewer {...props} />
+    } else {
+        return <PreviewNotSupported />
     }
 }

--- a/components/file-explorer/viewers/not-supported.tsx
+++ b/components/file-explorer/viewers/not-supported.tsx
@@ -1,6 +1,11 @@
-import { EyeOff } from "lucide-react"
+import { Compass, EyeOff } from "lucide-react"
+import { useMemo } from "react"
 
 export function PreviewNotSupported() {
+    const usesSafari = useMemo(() => {
+        return navigator.userAgent.toLowerCase().includes("safari")
+    }, [])
+
     return (
         <div className="grow flex justify-center items-center">
             <div className="flex flex-col justify-center items-center p-10 text-center text-muted-foreground">
@@ -10,6 +15,13 @@ export function PreviewNotSupported() {
                     There is no preview available for this file type. Download it to view it or
                     select a different file to preview.
                 </div>
+                {usesSafari && (
+                    <div className="mt-8 p-4 bg-muted text-sm rounded max-w-80 flex items-center flex-col gap-2">
+                        <Compass className="size-6" />
+                        It seems like you are using Safari. Due to technical limitations, only few
+                        specific files can be previewed with Safari.
+                    </div>
+                )}
             </div>
         </div>
     )


### PR DESCRIPTION
Closes #28 