### PR TITLE
Fix number field detection

### DIFF
--- a/components/editor/property-hooks.ts
+++ b/components/editor/property-hooks.ts
@@ -49,10 +49,15 @@ export function usePropertyCanBe(
 
     const canBeNumber = useMemo(() => {
         return propertyRange
-            ? propertyRange.includes(SCHEMA_ORG_NUMBER) ||
-                  SCHEMA_ORG_NUMBERLIKE.find((s) => propertyRange.includes(s)) !== undefined
+            ? (propertyRange.includes(SCHEMA_ORG_NUMBER) ||
+                  SCHEMA_ORG_NUMBERLIKE.find((s) => propertyRange.includes(s)) !== undefined) &&
+                  textValueGuard(
+                      value,
+                      (v) => !isNaN(parseFloat(v)) && parseFloat(v) + "" === v,
+                      true
+                  )
             : undefined
-    }, [propertyRange])
+    }, [propertyRange, value])
 
     const canBeDate = useMemo(() => {
         return (


### PR DESCRIPTION
Before using the field type number, it is now checked that the value of the property can even be parsed into a float