### PR TITLE
Change feedback button to go to GitHub issues

### DIFF
--- a/components/nav/nav-sidebar.tsx
+++ b/components/nav/nav-sidebar.tsx
@@ -84,7 +84,7 @@ export function NavSidebar({ children }: PropsWithChildren) {
                             Validation
                         </Button>
 
-                        <Link href={"mailto:christopher.raquet@kit.edu"}>
+                        <Link href={"https://github.com/kit-data-manager/NovaCrate/issues"}>
                             <Button variant="link" className={`justify-start w-full`}>
                                 <MessageSquare className="size-4 mr-2" />
                                 Send Feedback


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the "Send Feedback" link in the navigation sidebar to direct users to the project's GitHub issues page instead of an email address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->