### PR TITLE
Don't show target entity id in reference fields

### DIFF
--- a/components/editor/reference-field.tsx
+++ b/components/editor/reference-field.tsx
@@ -145,26 +145,29 @@ export const ReferenceField = memo(function ReferenceField({
                 </>
             ) : (
                 <>
-                    <Button
-                        className="shrink grow rounded-r-none justify-start pl-2 truncate min-w-0"
-                        variant="outline"
-                        onClick={openInNewTab}
-                    >
-                        {isExternalLink ? (
-                            <ExternalLink className="size-4 mr-1" />
-                        ) : (
-                            <EntityIcon className="mr-1" entity={referencedEntity} />
-                        )}
-                        <div className="flex items-end truncate grow">
-                            <ReferenceText />
-                            <span className="text-muted-foreground ml-1 text-xs truncate">
-                                {!isExternalLink && value["@id"]}
-                            </span>
-                            <div className="flex items-center self-center grow justify-end">
-                                {referencedEntity && <Eye className="size-4" />}
-                            </div>
-                        </div>
-                    </Button>
+                    <Tooltip delayDuration={1000}>
+                        <TooltipTrigger asChild>
+                            <Button
+                                className="shrink grow rounded-r-none justify-start pl-2 truncate min-w-0"
+                                variant="outline"
+                                onClick={openInNewTab}
+                            >
+                                {isExternalLink ? (
+                                    <ExternalLink className="size-4 mr-1" />
+                                ) : (
+                                    <EntityIcon className="mr-1" entity={referencedEntity} />
+                                )}
+                                <div className="flex items-end truncate grow">
+                                    <ReferenceText />
+                                    <div className="flex items-center self-center grow justify-end">
+                                        {referencedEntity && <Eye className="size-4" />}
+                                    </div>
+                                </div>
+                            </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>Identifier: {value["@id"]}</TooltipContent>
+                    </Tooltip>
+
                     {!referencedEntity && !isExternalLink && (
                         <Tooltip>
                             <TooltipTrigger asChild>

--- a/tests/entity-editor.test.ts
+++ b/tests/entity-editor.test.ts
@@ -242,10 +242,10 @@ test("Add Reference and follow it", async ({ page }) => {
     await page.getByRole("button", { name: "Link" }).click()
     await page.getByLabel("Suggestions").getByText("FJSON Result FileFile").click()
     await expect(page.locator("body")).toMatchAriaSnapshot(`
-    - button "F JSON Result File result.json"
+    - button "F JSON Result File"
     - button
     - button
-    - button "F JSON Result File result.json"
+    - button "F JSON Result File"
     - button
     - button
     - button "Add another entry"
@@ -253,15 +253,15 @@ test("Add Reference and follow it", async ({ page }) => {
     await expect(page.locator(".bg-info")).toBeVisible()
     await page.getByRole("button", { name: "Save" }).click()
     await expect(page.locator("body")).toMatchAriaSnapshot(`
-    - button "F JSON Result File result.json"
+    - button "F JSON Result File"
     - button
     - button
-    - button "F JSON Result File result.json"
+    - button "F JSON Result File"
     - button
     - button
     - button "Add another entry"
     `)
-    await page.getByRole("button", { name: "F JSON Result File result.json" }).nth(1).click()
+    await page.getByRole("button", { name: "F JSON Result File" }).nth(1).click()
     await expect(page.locator("body")).toMatchAriaSnapshot(`
     - heading "File JSON Result File" [level=2]:
       - button "File"

--- a/tests/importing.test.ts
+++ b/tests/importing.test.ts
@@ -32,7 +32,7 @@ async function testCrateContent(page: Page) {
     - button "Add another entry"
     - text: Has Part
     - paragraph: Indicates an item or CreativeWork that is part of this item, or CreativeWork (in some sense).
-    - button "F JSON Result File result.json"
+    - button "F JSON Result File"
     - button
     - button
     - button "Add another entry"
@@ -62,7 +62,7 @@ async function testCrateContent(page: Page) {
     - button "Is Family Friendly"
     - button "Version"
     `)
-    await page.getByRole("button", { name: "F JSON Result File result.json" }).click()
+    await page.getByRole("button", { name: "F JSON Result File", exact: true }).click()
     await expect(page.getByRole("heading").getByText("JSON Result File")).toBeVisible()
     await expect(page.locator("body")).toMatchAriaSnapshot(`
     - heading "File JSON Result File" [level=2]:
@@ -156,16 +156,16 @@ test("Import Folder", async ({ page }) => {
     await expect(page.getByRole("textbox").first()).toHaveValue("Uploaded from Folder")
     await expect(page.getByRole("textbox").nth(1)).toHaveValue("Custom Description Text")
     await expect(page.locator("body")).toMatchAriaSnapshot(`
-    - button "F candles-9247498_1280.jpg img/candles-9247498_1280.jpg"
+    - button "F candles-9247498_1280.jpg"
     - button
     - button
-    - button "F description.txt description.txt"
+    - button "F description.txt"
     - button
     - button
-    - button "F empty-file empty-file"
+    - button "F empty-file"
     - button
     - button
-    - button "F example.json example.json"
+    - button "F example.json"
     - button
     - button
     - button "Add another entry"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a tooltip to reference buttons in the editor, displaying the identifier on hover with a short delay.

* **Style**
  * Simplified button labels by removing redundant filename suffixes for a cleaner interface.

* **Tests**
  * Updated test assertions and selectors to match the revised button labels and tooltip behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->