### PR TITLE
Remove next navigation guard

### DIFF
--- a/app/editor/full/layout.tsx
+++ b/app/editor/full/layout.tsx
@@ -18,25 +18,22 @@ import { ValidationContextProvider } from "@/components/providers/validation-con
 import { CrateValidationSupervisor } from "@/components/crate-validation-supervisor"
 import { DataSaveHint } from "@/components/data-save-hint"
 import { UnsavedChangesProtector } from "@/components/UnsavedChangesProtector"
-import { NavigationGuardProvider } from "next-navigation-guard"
 
 export default function EditorLayout(props: PropsWithChildren) {
     return (
-        <NavigationGuardProvider>
-            <ActionsProvider>
-                <SchemaWorkerProvider>
-                    <GlobalModalProvider>
-                        <GraphStateProvider>
-                            <GraphSettingsProvider>
-                                <ValidationContextProvider>
-                                    <ProviderBoundary>{props.children}</ProviderBoundary>
-                                </ValidationContextProvider>
-                            </GraphSettingsProvider>
-                        </GraphStateProvider>
-                    </GlobalModalProvider>
-                </SchemaWorkerProvider>
-            </ActionsProvider>
-        </NavigationGuardProvider>
+        <ActionsProvider>
+            <SchemaWorkerProvider>
+                <GlobalModalProvider>
+                    <GraphStateProvider>
+                        <GraphSettingsProvider>
+                            <ValidationContextProvider>
+                                <ProviderBoundary>{props.children}</ProviderBoundary>
+                            </ValidationContextProvider>
+                        </GraphSettingsProvider>
+                    </GraphStateProvider>
+                </GlobalModalProvider>
+            </SchemaWorkerProvider>
+        </ActionsProvider>
     )
 }
 

--- a/components/UnsavedChangesProtector.tsx
+++ b/components/UnsavedChangesProtector.tsx
@@ -1,6 +1,5 @@
 import { useEffect } from "react"
 import { useEditorState } from "@/lib/state/editor-state"
-import { useNavigationGuard } from "next-navigation-guard"
 
 export function UnsavedChangesProtector() {
     const hasUnsavedChanges = useEditorState((s) => s.getHasUnsavedChanges())
@@ -17,14 +16,6 @@ export function UnsavedChangesProtector() {
 
         return () => window.removeEventListener("beforeunload", listener)
     }, [hasUnsavedChanges])
-
-    useNavigationGuard({
-        enabled: hasUnsavedChanges,
-        confirm: () =>
-            window.confirm(
-                "You have unsaved changes. Leaving the page means you will lose your changes. Are you sure you want to leave the page?"
-            )
-    })
 
     return null
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,6 @@
                 "monaco-editor": "^0.55.0",
                 "motion": "^12.23.24",
                 "next": "^16.0.10",
-                "next-navigation-guard": "^0.2.0",
                 "next-themes": "^0.4.4",
                 "prettier": "^3.2.5",
                 "pretty-bytes": "^7.0.0",
@@ -9554,16 +9553,6 @@
                 "sass": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/next-navigation-guard": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/next-navigation-guard/-/next-navigation-guard-0.2.0.tgz",
-            "integrity": "sha512-EnQcqJi/bcHXnirnY0TGSFkQ3Rl9ID4BZWdU2ovoWAkA72mCofI2hTcaqUUOmlSBVZp4AvSGm1kQmkOJDLrEjg==",
-            "license": "MIT",
-            "peerDependencies": {
-                "next": "^14 || ^15",
-                "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
             }
         },
         "node_modules/next-themes": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "monaco-editor": "^0.55.0",
     "motion": "^12.23.24",
     "next": "^16.0.10",
-    "next-navigation-guard": "^0.2.0",
     "next-themes": "^0.4.4",
     "prettier": "^3.2.5",
     "pretty-bytes": "^7.0.0",
@@ -93,11 +92,6 @@
     "webpack": "5.103.0",
     "webpack-bundle-analyzer": "5.1.0",
     "webpack-cli": "6.0.1"
-  },
-  "overrides": {
-    "next-navigation-guard": {
-      "next": "^16.0.0"
-    }
   },
   "description": "Web-based interactive editor for creating, editing and visualising research object crates.",
   "keywords": [


### PR DESCRIPTION
Next navigation guard was responsible for #274 , removing it completely because there doesnt seem to be a better replacement. Navigating to a different domain still shows the native warning.

Closes #274 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal provider architecture for improved maintainability.
  * Removed unused navigation guard dependency to reduce bundle size and external dependencies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->