### PR TITLE
fix: remove confidence matcher from renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,10 +4,9 @@
     "minimumReleaseAge": "3 days",
     "packageRules": [
         {
-            "groupName": "high confidence minor and patch dependencies",
+            "groupName": "minor and patch dependencies",
             "matchManagers": ["npm"],
-            "matchUpdateTypes": ["minor", "patch"],
-            "matchConfidence": ["very high", "high"]
+            "matchUpdateTypes": ["minor", "patch"]
         }
     ],
     "rangeStrategy": "replace",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified dependency update rules configuration to broaden coverage by removing confidence-level filtering restrictions, allowing a wider range of npm packages to be eligible for minor and patch updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->