### PR TITLE
fix: dont jump to last page in main menu when creating crate

### DIFF
--- a/app/editor/page.tsx
+++ b/app/editor/page.tsx
@@ -387,7 +387,7 @@ export default function EditorLandingPage() {
                             <div className="text-muted-foreground text-xs">Actions</div>
                         </div>
 
-                        <Pagination pageSize={15}>
+                        <Pagination pageSize={15} jumpToEndOnChildAdd={false}>
                             {recentCratesLoading || storedCratesLoading ? (
                                 <div>
                                     {[0, 0, 0].map((_, i) => {

--- a/components/pagination.tsx
+++ b/components/pagination.tsx
@@ -19,10 +19,12 @@ const DEFAULT_PAGE_SIZE = 10
 export function Pagination({
     children,
     pageSize = DEFAULT_PAGE_SIZE,
-    leftContent
+    leftContent,
+    jumpToEndOnChildAdd = true
 }: PropsWithChildren<{
     pageSize?: number
     leftContent?: ReactElement
+    jumpToEndOnChildAdd?: boolean
 }>) {
     const [page, setPage] = useState(0)
     const [jumpToPageValue, setJumpToPageValue] = useState("1")
@@ -51,15 +53,20 @@ export function Pagination({
         return Math.floor((childrenLength - 1) / pageSize) + 1
     }, [childrenLength, pageSize])
 
+    // Jump to the last page if a new child was added and jumpToEndOnChildAdd is true
     useEffect(() => {
         if (lastChildrenLength.current >= 0) {
             // If last children length was 1 or less, assume it was just a loading skeleton -> do not jump to last page
-            if (childrenLength > lastChildrenLength.current && lastChildrenLength.current > 1) {
+            if (
+                childrenLength > lastChildrenLength.current &&
+                lastChildrenLength.current > 1 &&
+                jumpToEndOnChildAdd
+            ) {
                 setPage(pageCount - 1)
             }
         }
         lastChildrenLength.current = childrenLength
-    }, [childrenLength, pageCount])
+    }, [childrenLength, jumpToEndOnChildAdd, pageCount])
 
     useEffect(() => {
         if (page >= pageCount) {


### PR DESCRIPTION
Fix #315 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Pagination component now includes a configurable option to control auto-jumping behavior when new items are added. By default, pagination continues to jump to the last page when items are added, ensuring backward compatibility. This setting allows for more flexible pagination control in different contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->