### PR TITLE
Fix explorer button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed security vulnerabilities and installed countermeasures against npm supply chain attacks
 - Fixed a validation issue where Dataset entities were not being validated correctly
 - Fixed the search button in entity explorer
+- Fixed the tooltip of a button in the file explorer
 
 ## [1.11.1] - 2026-05-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed security vulnerabilities and installed countermeasures against npm supply chain attacks
 - Fixed a validation issue where Dataset entities were not being validated correctly
+- Fixed the search button in entity explorer
 
 ## [1.11.1] - 2026-05-18
 

--- a/components/actions/action-buttons.tsx
+++ b/components/actions/action-buttons.tsx
@@ -13,6 +13,7 @@ export interface GenericActionContentProps {
     noShortcut?: boolean
     iconOnly?: boolean
     hideName?: boolean
+    ignoreOnClickFromProps?: boolean
 }
 
 function GenericActionContent(props: GenericActionContentProps) {
@@ -118,6 +119,9 @@ function cleanProps<T extends object>(props: T) {
     if ("closeAnd" in newData) delete newData.closeAnd
     if ("iconOnly" in newData) delete newData.iconOnly
     if ("hideName" in newData) delete newData.hideName
+
+    if ("ignoreOnClickFromProps" in newData && newData.ignoreOnClickFromProps)
+        if ("onClick" in newData) delete newData.onClick
 
     return newData
 }

--- a/components/actions/action-buttons.tsx
+++ b/components/actions/action-buttons.tsx
@@ -120,8 +120,10 @@ function cleanProps<T extends object>(props: T) {
     if ("iconOnly" in newData) delete newData.iconOnly
     if ("hideName" in newData) delete newData.hideName
 
-    if ("ignoreOnClickFromProps" in newData && newData.ignoreOnClickFromProps)
-        if ("onClick" in newData) delete newData.onClick
+    if ("ignoreOnClickFromProps" in newData) {
+        if (newData.ignoreOnClickFromProps && "onClick" in newData) delete newData.onClick
+        delete newData.ignoreOnClickFromProps
+    }
 
     return newData
 }

--- a/components/entity-browser/entity-browser.tsx
+++ b/components/entity-browser/entity-browser.tsx
@@ -87,6 +87,7 @@ export function EntityBrowser() {
                                 size={"sm"}
                                 noShortcut
                                 iconOnly
+                                ignoreOnClickFromProps
                             />
                         </TooltipTrigger>
                         <TooltipContent>Global Search</TooltipContent>

--- a/components/file-explorer/explorer.tsx
+++ b/components/file-explorer/explorer.tsx
@@ -209,7 +209,7 @@ export function FileExplorer() {
                     </div>
                 </HelpTooltip>
                 <div className="grow" />
-                <Tooltip>
+                <Tooltip delayDuration={300}>
                     <TooltipTrigger asChild>
                         <Button
                             id="toggle-show-entities"
@@ -224,7 +224,7 @@ export function FileExplorer() {
                             />
                         </Button>
                     </TooltipTrigger>
-                    <TooltipContent>Show entities next to file names</TooltipContent>
+                    <TooltipContent>Show matching entities</TooltipContent>
                 </Tooltip>
                 <ActionButton
                     variant="outline"


### PR DESCRIPTION
Closes #395 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the search button behavior in the entity explorer.
  * Updated the file explorer’s header tooltip for the entities toggle to use a tuned display delay and clearer text (“Show matching entities”), improving the tooltip experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->