### PR TITLE
feat: show confirmation dialog when attempting to delete an entity

### DIFF
--- a/components/ai/chat.tsx
+++ b/components/ai/chat.tsx
@@ -107,6 +107,17 @@ export default function AIAssistantChat() {
         setMessages([])
     }, [setMessages])
 
+    const hasUnansweredToolCalls = useMemo(() => {
+        return messages.some((m) =>
+            m.parts.some(
+                (p) =>
+                    p.type.startsWith("tool-") && // Even though this is hard-typed for tool-deleteEntity, it works for all tool calls
+                    (p as NC_UIMessage["parts"][number] & { type: "tool-deleteEntity" }).state ===
+                        "input-available"
+            )
+        )
+    }, [messages])
+
     const chatContainer = useRef<HTMLDivElement>(null)
     const chatContent = useRef<HTMLDivElement>(null)
     const stickToBottom = useRef(true)
@@ -121,10 +132,12 @@ export default function AIAssistantChat() {
 
     const sendMessage = useCallback(
         (msg: string) => {
+            if (status === "streaming" || status === "submitted") return false
+
             const activeProvider = settings.getActiveProvider()
             if (!activeProvider || !activeProvider.selectedModel) {
                 toast.error("Please select a model first")
-                return
+                return false
             }
 
             scrollChatToBottom()
@@ -136,8 +149,10 @@ export default function AIAssistantChat() {
                         (err instanceof Error ? err.message : JSON.stringify(err))
                 )
             })
+
+            return true
         },
-        [_sendMessage, scrollChatToBottom, settings]
+        [_sendMessage, scrollChatToBottom, settings, status]
     )
 
     const editMessage = useCallback(
@@ -305,6 +320,7 @@ export default function AIAssistantChat() {
                             message={message}
                             key={message.id}
                             editMessage={(newContent) => editMessage(message, newContent)}
+                            addToolOutput={addToolOutput}
                         />
                     ))}
                 </div>
@@ -336,6 +352,7 @@ export default function AIAssistantChat() {
                         !settings.activeProvider || !settings.getActiveProvider()?.selectedModel
                     }
                     stop={stop}
+                    hide={hasUnansweredToolCalls}
                 />
                 <ModelSelection />
                 <div className="text-xs font-light text-center text-muted-foreground p-2 pb-0">

--- a/components/ai/delete-entity-tool.tsx
+++ b/components/ai/delete-entity-tool.tsx
@@ -1,0 +1,129 @@
+import type { NC_UIMessage } from "@/lib/ai/types"
+import { LoaderCircle, TrashIcon, XIcon } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { ToolCall } from "@/components/ai/tool-call"
+import { useCallback, useState } from "react"
+import { ChatAddToolOutputFunction } from "ai"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { useCore } from "@/components/providers/core-provider"
+import { EntityIcon } from "@/components/entity/entity-icon"
+import { useEditorState } from "@/lib/state/editor-state"
+import { useShallow } from "zustand/react/shallow"
+import { findEntity, getEntityDisplayName } from "@/lib/utils"
+import { useGoToEntityEditor } from "@/lib/hooks/hooks"
+
+export function DeleteEntityTool({
+    addToolOutput,
+    part
+}: {
+    part: NC_UIMessage["parts"][number] & { type: "tool-deleteEntity" } // a message part of type tool-deleteEntity
+    addToolOutput: ChatAddToolOutputFunction<NC_UIMessage>
+}) {
+    const core = useCore()
+    const entity = useEditorState(
+        useShallow((store) =>
+            part.input?.entityId ? findEntity(store.getEntities(), part.input.entityId) : undefined
+        )
+    )
+    const goToEntity = useGoToEntityEditor(entity)
+
+    const respondWithError = useCallback(
+        (e: unknown) => {
+            addToolOutput({
+                tool: "deleteEntity",
+                toolCallId: part.toolCallId,
+                state: "output-error",
+                errorText:
+                    typeof e === "string" ? e : e instanceof Error ? e.message : JSON.stringify(e)
+            })
+        },
+        [addToolOutput, part.toolCallId]
+    )
+
+    const respondWithSuccess = useCallback(() => {
+        addToolOutput({
+            tool: "deleteEntity",
+            toolCallId: part.toolCallId,
+            state: "output-available",
+            output: {}
+        })
+    }, [addToolOutput, part.toolCallId])
+
+    const [isDeleting, setIsDeleting] = useState(false)
+    const onDeleteEntityClick = useCallback(
+        (part: NC_UIMessage["parts"][number] & { type: "tool-deleteEntity" }) => {
+            if (!part.input || !part.input.entityId) {
+                respondWithError(
+                    "Tool call incomplete. Either the input is completely missing, or the entityId is missing."
+                )
+                return
+            }
+
+            setIsDeleting(true)
+            // We directly call the core-level method here to forward error messages to the AI instead of the UI
+            // deleteEntity from crate mutations would catch the error and display it to UI
+            core.deleteEntity(part.input.entityId, part.input.deleteData ?? false)
+                .then(() => {
+                    respondWithSuccess()
+                })
+                .catch((e: unknown) => {
+                    console.error("Failed to delete file", e)
+                    respondWithError(e)
+                })
+                .finally(() => {
+                    setIsDeleting(false)
+                })
+        },
+        [core, respondWithError, respondWithSuccess]
+    )
+
+    const onDeleteDenyClick = useCallback(
+        (part: NC_UIMessage["parts"][number] & { type: "tool-deleteEntity" }) => {
+            if (!part.input) {
+                return
+            }
+
+            addToolOutput({
+                tool: "deleteEntity",
+                toolCallId: part.toolCallId,
+                state: "output-error",
+                errorText: "The user has denied the delete operation"
+            })
+        },
+        [addToolOutput]
+    )
+
+    if (part.state === "input-available") {
+        return (
+            <Alert>
+                {isDeleting ? <LoaderCircle className="size-4 animate-spin" /> : <TrashIcon />}
+                <AlertTitle>Confirmation required</AlertTitle>
+                <AlertDescription>
+                    The AI Assistant wants to delete the following entity:
+                    <div className="p-1 pl-2">
+                        <Button onClick={() => goToEntity()} variant="outline" className="px-2">
+                            <EntityIcon entity={entity} />
+                            {entity && getEntityDisplayName(entity, true)}
+                        </Button>
+                    </div>
+                    {part.input.deleteData &&
+                        "The referenced files/folders and any contained files/folders will also irreversibly be deleted."}
+                    <div className="flex items-center gap-2 justify-end pt-2">
+                        <Button variant={"secondary"} onClick={() => onDeleteDenyClick(part)}>
+                            <XIcon /> Abort
+                        </Button>
+                        <Button variant="destructive" onClick={() => onDeleteEntityClick(part)}>
+                            <TrashIcon /> Delete
+                        </Button>
+                    </div>
+                </AlertDescription>
+            </Alert>
+        )
+    } else {
+        return (
+            <ToolCall part={part} icon={TrashIcon}>
+                Delete Entity {part.input?.entityId ?? "..."}
+            </ToolCall>
+        )
+    }
+}

--- a/components/ai/delete-entity-tool.tsx
+++ b/components/ai/delete-entity-tool.tsx
@@ -80,17 +80,13 @@ export function DeleteEntityTool({
     const onDeleteDenyClick = useCallback(
         (part: NC_UIMessage["parts"][number] & { type: "tool-deleteEntity" }) => {
             if (!part.input) {
+                respondWithError("Tool call incomplete. The input is missing.")
                 return
             }
 
-            addToolOutput({
-                tool: "deleteEntity",
-                toolCallId: part.toolCallId,
-                state: "output-error",
-                errorText: "The user has denied the delete operation"
-            })
+            respondWithError("The user has denied the delete operation")
         },
-        [addToolOutput]
+        [respondWithError]
     )
 
     if (part.state === "input-available") {

--- a/components/ai/input.tsx
+++ b/components/ai/input.tsx
@@ -8,21 +8,26 @@ export function ChatInput({
     sendMessage: _sendMessage,
     stop,
     status,
-    disableSend
+    disableSend,
+    hide
 }: {
-    sendMessage: (msg: string) => void
+    sendMessage: (msg: string) => boolean
     stop: () => void
     status: ChatStatus
     disableSend?: boolean
+    hide?: boolean
 }) {
     const [message, setMessage] = useState("")
 
     const sendMessage = useCallback(() => {
         if (disableSend) return
         if (!message.trim()) return
-        setMessage("")
-        _sendMessage(message)
+
+        const result = _sendMessage(message)
+        if (result) setMessage("")
     }, [_sendMessage, disableSend, message])
+
+    if (hide) return null
 
     return (
         <div className="flex items-end gap-2">

--- a/components/ai/message.tsx
+++ b/components/ai/message.tsx
@@ -10,25 +10,21 @@ import {
     TableRow
 } from "@/components/ui/table"
 import { ToolCall } from "@/components/ai/tool-call"
-import {
-    BugIcon,
-    ChevronRight,
-    EyeIcon,
-    LoaderCircle,
-    PencilIcon,
-    PlusIcon,
-    TrashIcon
-} from "lucide-react"
+import { BugIcon, ChevronRight, EyeIcon, LoaderCircle, PencilIcon, PlusIcon } from "lucide-react"
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible"
 import type { NC_UIMessage } from "@/lib/ai/types"
 import { UserMessage } from "@/components/ai/user-message"
+import { ChatAddToolOutputFunction } from "ai"
+import { DeleteEntityTool } from "@/components/ai/delete-entity-tool"
 
 export const Message = memo(function Message({
     message: m,
-    editMessage
+    editMessage,
+    addToolOutput
 }: {
     message: NC_UIMessage
     editMessage: (text: string) => void
+    addToolOutput: ChatAddToolOutputFunction<NC_UIMessage>
 }) {
     if (m.role === "user") {
         return <UserMessage message={m} editMessage={editMessage} />
@@ -170,11 +166,7 @@ export const Message = memo(function Message({
                 }
 
                 if (part.type === "tool-deleteEntity") {
-                    return (
-                        <ToolCall key={i} part={part} icon={TrashIcon}>
-                            Delete Entity {part.input?.entityId ?? "..."}
-                        </ToolCall>
-                    )
+                    return <DeleteEntityTool key={i} part={part} addToolOutput={addToolOutput} />
                 }
 
                 if (part.type === "tool-importPersonFromORCID") {

--- a/components/modals/delete-entity-modal.tsx
+++ b/components/modals/delete-entity-modal.tsx
@@ -5,7 +5,6 @@ import { AlertTriangleIcon, ArrowLeft, Loader2, Trash } from "lucide-react"
 import { editorState, useEditorState } from "@/lib/state/editor-state"
 import { useCrateMutations } from "@/lib/hooks/use-crate-mutations"
 import { usePersistence } from "@/components/providers/persistence-provider"
-import { useCore } from "@/components/providers/core-provider"
 import {
     getEntityDisplayName,
     isContextualEntity,
@@ -31,7 +30,6 @@ export const DeleteEntityModal = memo(function DeleteEntityModal({
     const entity = useEditorState((store) => store.entities.get(entityId))
     const { deleteEntity } = useCrateMutations()
     const persistence = usePersistence()
-    const core = useCore()
     const [isDeleting, setIsDeleting] = useState(false)
     const [deleteError, setDeleteError] = useState<unknown>()
     const [deleteContent, setDeleteContent] = useState(false)
@@ -48,40 +46,22 @@ export const DeleteEntityModal = memo(function DeleteEntityModal({
     )
 
     const onDeleteEntityClick = useCallback(() => {
-        if (entity) {
-            setIsDeleting(true)
-            deleteEntity(entity, deleteContent)
-                .then((success: boolean) => {
-                    if (success) {
-                        setDeleteError(undefined)
-                        onOpenChange(false)
-                    } else setDeleteError("Unknown error while deleting")
-                })
-                .catch((e: unknown) => {
-                    console.error(e)
-                    setDeleteError(e)
-                })
-                .finally(() => {
-                    setIsDeleting(false)
-                })
-        } else {
-            // Attempt to delete anyway. The user was able to access the delete button, so there must be something here...
-            // Assumes the type to be a file, since files can exist without having an entity
-            setIsDeleting(true)
-            core.deleteEntity(entityId, deleteContent)
-                .then(() => {
+        setIsDeleting(true)
+        deleteEntity(entity ?? { "@id": entityId, "@type": "" }, deleteContent)
+            .then((success: boolean) => {
+                if (success) {
                     setDeleteError(undefined)
                     onOpenChange(false)
-                })
-                .catch((e: unknown) => {
-                    console.error(e)
-                    setDeleteError(e)
-                })
-                .finally(() => {
-                    setIsDeleting(false)
-                })
-        }
-    }, [entity, core, deleteEntity, onOpenChange, entityId, deleteContent])
+                } else setDeleteError("Unknown error while deleting")
+            })
+            .catch((e: unknown) => {
+                console.error(e)
+                setDeleteError(e)
+            })
+            .finally(() => {
+                setIsDeleting(false)
+            })
+    }, [entity, deleteEntity, onOpenChange, entityId, deleteContent])
 
     const couldHaveFile = useMemo(() => {
         return entity ? !isContextualEntity(entity) : true

--- a/components/modals/delete-entity-modal.tsx
+++ b/components/modals/delete-entity-modal.tsx
@@ -47,7 +47,7 @@ export const DeleteEntityModal = memo(function DeleteEntityModal({
 
     const onDeleteEntityClick = useCallback(() => {
         setIsDeleting(true)
-        deleteEntity(entity ?? { "@id": entityId, "@type": "" }, deleteContent)
+        deleteEntity(entity ?? { "@id": entityId, "@type": [] }, deleteContent)
             .then((success: boolean) => {
                 if (success) {
                     setDeleteError(undefined)

--- a/lib/ai/use-frontend-tool-handler.ts
+++ b/lib/ai/use-frontend-tool-handler.ts
@@ -285,25 +285,6 @@ export function useFrontendToolHandler() {
 
                     return
                 }
-                case "deleteEntity": {
-                    try {
-                        await core.deleteEntity(toolCall.input.entityId, toolCall.input.deleteData)
-                        addToolOutput({
-                            tool: "deleteEntity",
-                            toolCallId: toolCall.toolCallId,
-                            output: {}
-                        })
-                        readEntities.delete(toolCall.input.entityId)
-                    } catch (e) {
-                        addToolOutput({
-                            tool: "deleteEntity",
-                            toolCallId: toolCall.toolCallId,
-                            state: "output-error",
-                            errorText: `Failed to delete entity. ${e instanceof Error ? e.message : JSON.stringify(e)}`
-                        })
-                    }
-                    return
-                }
                 case "moveEntity": {
                     try {
                         await core.moveEntity(

--- a/lib/state/operation-state.ts
+++ b/lib/state/operation-state.ts
@@ -14,8 +14,6 @@ export type HealthStatus = "healthy" | "unhealthy" | "unknown"
  * `saveErrors`, `loadError`, and worker `healthStatus`/`healthError`.
  *
  * Accessed via {@link useOperationState} or directly via {@link operationState}.
- *
- * TODO Is this even displayed anywhere in the UI?
  */
 export interface OperationState {
     // ── Saving state ────────────────────────────────────────────────────

--- a/lib/state/operation-state.ts
+++ b/lib/state/operation-state.ts
@@ -14,6 +14,8 @@ export type HealthStatus = "healthy" | "unhealthy" | "unknown"
  * `saveErrors`, `loadError`, and worker `healthStatus`/`healthError`.
  *
  * Accessed via {@link useOperationState} or directly via {@link operationState}.
+ *
+ * TODO Is this even displayed anywhere in the UI?
  */
 export interface OperationState {
     // ── Saving state ────────────────────────────────────────────────────


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a guided delete confirmation flow in AI chat for entities, including a clear confirmation step and success/error feedback.
  * Chat messages can now surface action-specific controls directly within the conversation.

* **Bug Fixes**
  * The chat input now stays hidden while an AI tool action is waiting for a response, preventing conflicting messages.
  * Message sending now correctly blocks duplicate submissions and only clears the input after a successful send.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->