### PR TITLE
feat: remember last viewport position and node layout in graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added help tooltips to the AI Assistant configuration modal
+- The graph view now remembers the last viewport position and node layout for the duration of the session
 
 ### Changed
 - Updated the documentation modal to add links to guides on GitHub and the YouTube tutorial series

--- a/components/graph/entity-graph.tsx
+++ b/components/graph/entity-graph.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import React, { createRef, useCallback, useEffect, useRef, useContext } from "react"
+import React, { createRef, useCallback, useEffect, useContext } from "react"
 import ReactFlow, {
     Background,
     Connection,
@@ -165,7 +165,12 @@ export function EntityGraph() {
         aggregateProperties
     } = useGraphSettings()
 
-    const { fitView } = useReactFlow()
+    const { fitView, getViewport } = useReactFlow()
+
+    const initialFormatDone = useGraphState((s) => s.initialFormatDone)
+    const setInitialFormatDone = useGraphState((s) => s.setInitialFormatDone)
+    const viewport = useGraphState((s) => s.viewport)
+    const setViewport = useGraphState((s) => s.setViewport)
 
     const contextMenuTriggerRef = createRef<HTMLDivElement>()
 
@@ -314,23 +319,18 @@ export function EntityGraph() {
     )
 
     useEffect(() => {
-        if (
-            nodes.length > 1 &&
-            !nodes.find(
-                (node) => node.position.x !== DEFAULT_POS.x || node.position.y !== DEFAULT_POS.y
-            )
-        ) {
+        if (nodesInitialized && !initialFormatDone) {
             reformat(true)
+            setInitialFormatDone()
         }
-    }, [nodes, reformat])
+    }, [initialFormatDone, nodesInitialized, reformat, setInitialFormatDone])
 
-    const initialReformatDone = useRef(false)
-    useEffect(() => {
-        if (nodesInitialized && !initialReformatDone.current) {
-            reformat(true)
-            initialReformatDone.current = true
+    const onMoveEnd = useCallback(() => {
+        const vp = getViewport()
+        if (vp) {
+            setViewport(vp)
         }
-    }, [nodesInitialized, reformat])
+    }, [getViewport, setViewport])
 
     useOnSelectionChange({
         onChange: ({ nodes }) => {
@@ -348,8 +348,10 @@ export function EntityGraph() {
                 nodes={nodes}
                 edges={edges}
                 onConnect={onConnect}
+                defaultViewport={viewport}
                 onNodesChange={beforeNodesChange}
                 onEdgesChange={beforeEdgesChange}
+                onMoveEnd={onMoveEnd}
                 connectionLineType={ConnectionLineType.Bezier}
                 nodeTypes={nodeTypes}
                 deleteKeyCode={["Delete", "Backspace"]}

--- a/components/graph/layout.ts
+++ b/components/graph/layout.ts
@@ -1,10 +1,10 @@
 import dagre from "dagre"
 import { Edge, Node, Position } from "reactflow"
 
-const dagreGraph = new dagre.graphlib.Graph()
-dagreGraph.setDefaultEdgeLabel(() => ({}))
-
 export const computeGraphLayout = (nodes: Node[], edges: Edge[]) => {
+    const dagreGraph = new dagre.graphlib.Graph()
+    dagreGraph.setDefaultEdgeLabel(() => ({}))
+
     dagreGraph.setGraph({ rankdir: "LR" })
 
     nodes.forEach((node) => {

--- a/lib/state/graph-state.ts
+++ b/lib/state/graph-state.ts
@@ -2,7 +2,6 @@ import { applyEdgeChanges, applyNodeChanges, Edge, EdgeChange, Node, NodeChange 
 import { computeGraphLayout } from "@/components/graph/layout"
 import { create } from "zustand"
 import { unstable_ssrSafe as ssrSafe } from "zustand/middleware"
-import { persist } from "zustand/middleware"
 
 export interface GraphViewport {
     x: number
@@ -27,59 +26,47 @@ export interface GraphState {
 }
 
 export const useGraphState = create<GraphState>()(
-    ssrSafe(
-        persist(
-            (set, get) => ({
-                edges: [],
-                nodes: [],
-                selectedEntityID: undefined,
-                viewport: undefined,
-                initialFormatDone: false,
-                setSelectedEntityID(id: string) {
-                    set({ selectedEntityID: id })
-                },
-                updateNodes(newNodes: Node[]) {
-                    const nodes: Node[] = []
-                    for (const newNode of newNodes) {
-                        const oldNode = get().nodes.find((node) => node.id === newNode.id)
-                        if (oldNode) {
-                            nodes.push({
-                                ...newNode,
-                                position: oldNode.position
-                            })
-                        } else {
-                            nodes.push(newNode)
-                        }
-                    }
-                    set({ nodes })
-                },
-                autoLayout() {
-                    set(computeGraphLayout(get().nodes, get().edges))
-                },
-                handleNodesChange(changes: NodeChange[]) {
-                    set({ nodes: applyNodeChanges(changes, get().nodes) })
-                },
-                updateEdges(edges: Edge[]) {
-                    set({ edges })
-                },
-                handleEdgesChange(changes: EdgeChange[]) {
-                    set({ edges: applyEdgeChanges(changes, get().edges) })
-                },
-                setViewport(viewport: GraphViewport) {
-                    set({ viewport })
-                },
-                setInitialFormatDone() {
-                    set({ initialFormatDone: true })
+    ssrSafe((set, get) => ({
+        edges: [],
+        nodes: [],
+        selectedEntityID: undefined,
+        viewport: undefined,
+        initialFormatDone: false,
+        setSelectedEntityID(id: string) {
+            set({ selectedEntityID: id })
+        },
+        updateNodes(newNodes: Node[]) {
+            const nodes: Node[] = []
+            for (const newNode of newNodes) {
+                const oldNode = get().nodes.find((node) => node.id === newNode.id)
+                if (oldNode) {
+                    nodes.push({
+                        ...newNode,
+                        position: oldNode.position
+                    })
+                } else {
+                    nodes.push(newNode)
                 }
-            }),
-            {
-                name: "graph-state",
-                partialize: (state) => ({
-                    nodes: state.nodes,
-                    viewport: state.viewport,
-                    initialFormatDone: state.initialFormatDone
-                })
             }
-        )
-    )
+            set({ nodes })
+        },
+        autoLayout() {
+            set(computeGraphLayout(get().nodes, get().edges))
+        },
+        handleNodesChange(changes: NodeChange[]) {
+            set({ nodes: applyNodeChanges(changes, get().nodes) })
+        },
+        updateEdges(edges: Edge[]) {
+            set({ edges })
+        },
+        handleEdgesChange(changes: EdgeChange[]) {
+            set({ edges: applyEdgeChanges(changes, get().edges) })
+        },
+        setViewport(viewport: GraphViewport) {
+            set({ viewport })
+        },
+        setInitialFormatDone() {
+            set({ initialFormatDone: true })
+        }
+    }))
 )

--- a/lib/state/graph-state.ts
+++ b/lib/state/graph-state.ts
@@ -2,53 +2,84 @@ import { applyEdgeChanges, applyNodeChanges, Edge, EdgeChange, Node, NodeChange 
 import { computeGraphLayout } from "@/components/graph/layout"
 import { create } from "zustand"
 import { unstable_ssrSafe as ssrSafe } from "zustand/middleware"
+import { persist } from "zustand/middleware"
+
+export interface GraphViewport {
+    x: number
+    y: number
+    zoom: number
+}
 
 export interface GraphState {
     nodes: Node[]
     edges: Edge[]
     selectedEntityID: string | undefined
+    viewport: GraphViewport | undefined
+    initialFormatDone: boolean
     setSelectedEntityID(id: string): void
     updateNodes(nodes: Node[]): void
     autoLayout(): void
     handleNodesChange(changes: NodeChange[]): void
     updateEdges(edges: Edge[]): void
     handleEdgesChange(changes: EdgeChange[]): void
+    setViewport(viewport: GraphViewport): void
+    setInitialFormatDone(): void
 }
 
 export const useGraphState = create<GraphState>()(
-    ssrSafe((set, get) => ({
-        edges: [],
-        nodes: [],
-        selectedEntityID: undefined,
-        setSelectedEntityID(id: string) {
-            set({ selectedEntityID: id })
-        },
-        updateNodes(newNodes: Node[]) {
-            const nodes: Node[] = []
-            for (const newNode of newNodes) {
-                const oldNode = get().nodes.find((node) => node.id === newNode.id)
-                if (oldNode) {
-                    nodes.push({
-                        ...newNode,
-                        position: oldNode.position
-                    })
-                } else {
-                    nodes.push(newNode)
+    ssrSafe(
+        persist(
+            (set, get) => ({
+                edges: [],
+                nodes: [],
+                selectedEntityID: undefined,
+                viewport: undefined,
+                initialFormatDone: false,
+                setSelectedEntityID(id: string) {
+                    set({ selectedEntityID: id })
+                },
+                updateNodes(newNodes: Node[]) {
+                    const nodes: Node[] = []
+                    for (const newNode of newNodes) {
+                        const oldNode = get().nodes.find((node) => node.id === newNode.id)
+                        if (oldNode) {
+                            nodes.push({
+                                ...newNode,
+                                position: oldNode.position
+                            })
+                        } else {
+                            nodes.push(newNode)
+                        }
+                    }
+                    set({ nodes })
+                },
+                autoLayout() {
+                    set(computeGraphLayout(get().nodes, get().edges))
+                },
+                handleNodesChange(changes: NodeChange[]) {
+                    set({ nodes: applyNodeChanges(changes, get().nodes) })
+                },
+                updateEdges(edges: Edge[]) {
+                    set({ edges })
+                },
+                handleEdgesChange(changes: EdgeChange[]) {
+                    set({ edges: applyEdgeChanges(changes, get().edges) })
+                },
+                setViewport(viewport: GraphViewport) {
+                    set({ viewport })
+                },
+                setInitialFormatDone() {
+                    set({ initialFormatDone: true })
                 }
+            }),
+            {
+                name: "graph-state",
+                partialize: (state) => ({
+                    nodes: state.nodes,
+                    viewport: state.viewport,
+                    initialFormatDone: state.initialFormatDone
+                })
             }
-            set({ nodes })
-        },
-        autoLayout() {
-            set(computeGraphLayout(get().nodes, get().edges))
-        },
-        handleNodesChange(changes: NodeChange[]) {
-            set({ nodes: applyNodeChanges(changes, get().nodes) })
-        },
-        updateEdges(edges: Edge[]) {
-            set({ edges })
-        },
-        handleEdgesChange(changes: EdgeChange[]) {
-            set({ edges: applyEdgeChanges(changes, get().edges) })
-        }
-    }))
+        )
+    )
 )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The graph view now remembers your last zoom and position during the session.
  * The graph also keeps its layout state after the initial load, reducing repeated reformatting.

* **Bug Fixes**
  * Improved graph startup behavior so the view restores more consistently when reopening or revisiting the screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->