### PR TITLE
feat: remember panel sizes

### DIFF
--- a/app/editor/[mode]/entities/page.tsx
+++ b/app/editor/[mode]/entities/page.tsx
@@ -15,7 +15,7 @@ import { useGoToFileExplorer } from "@/lib/hooks/hooks"
 import { useEditorState } from "@/lib/state/editor-state"
 import { findEntity } from "@/lib/utils"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
-import { usePanelRef } from "react-resizable-panels"
+import { useDefaultLayout, usePanelRef } from "react-resizable-panels"
 
 function EntityEditorFilePreview(props: PropsWithChildren) {
     const previewingFilePath = useEntityEditorTabs((store) => store.previewingFilePath)
@@ -23,6 +23,10 @@ function EntityEditorFilePreview(props: PropsWithChildren) {
     const entities = useEditorState((s) => s.entities)
     const goToFileExplorer = useGoToFileExplorer(findEntity(entities, previewingFilePath))
     const openTab = useEntityEditorTabs((store) => store.openTab)
+
+    const { defaultLayout, onLayoutChanged } = useDefaultLayout({
+        id: "entity-editor-file-preview"
+    })
 
     const focusEntity = useCallback(() => {
         const entity = findEntity(entities, previewingFilePath)
@@ -40,7 +44,11 @@ function EntityEditorFilePreview(props: PropsWithChildren) {
     }
 
     return (
-        <ResizablePanelGroup orientation="horizontal">
+        <ResizablePanelGroup
+            orientation="horizontal"
+            defaultLayout={defaultLayout}
+            onLayoutChanged={onLayoutChanged}
+        >
             <ResizablePanel defaultSize={"66%"} minSize={"400px"}>
                 <div className="h-full w-full overflow-auto">{props.children}</div>
             </ResizablePanel>
@@ -102,6 +110,10 @@ export default function Entities() {
     const entityBrowserPanel = usePanelRef()
     const previewingFilePath = useEntityEditorTabs((store) => store.previewingFilePath)
 
+    const { defaultLayout, onLayoutChanged } = useDefaultLayout({
+        id: "entity-browser"
+    })
+
     const toggleEntityBrowserPanel = useCallback(() => {
         if (entityBrowserPanel.current) {
             if (!entityBrowserPanel.current.isCollapsed()) {
@@ -115,7 +127,11 @@ export default function Entities() {
     return (
         <>
             <Metadata page={"Entities"} />
-            <ResizablePanelGroup orientation={"horizontal"}>
+            <ResizablePanelGroup
+                orientation={"horizontal"}
+                defaultLayout={defaultLayout}
+                onLayoutChanged={onLayoutChanged}
+            >
                 <ResizablePanel
                     defaultSize={"400px"}
                     minSize={"200px"}

--- a/app/editor/[mode]/file-explorer/page.tsx
+++ b/app/editor/[mode]/file-explorer/page.tsx
@@ -4,10 +4,19 @@ import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "@/componen
 import { FileExplorer } from "@/components/file-explorer/explorer"
 import { FilePreview } from "@/components/file-explorer/preview"
 import { Metadata } from "@/components/Metadata"
+import { useDefaultLayout } from "react-resizable-panels"
 
 function Content() {
+    const { defaultLayout, onLayoutChanged } = useDefaultLayout({
+        id: "file-explorer"
+    })
+
     return (
-        <ResizablePanelGroup orientation="horizontal">
+        <ResizablePanelGroup
+            orientation="horizontal"
+            defaultLayout={defaultLayout}
+            onLayoutChanged={onLayoutChanged}
+        >
             <ResizablePanel defaultSize={"34%"} minSize={"400px"}>
                 <FileExplorer />
             </ResizablePanel>

--- a/components/entity-browser/entity-browser.tsx
+++ b/components/entity-browser/entity-browser.tsx
@@ -26,7 +26,7 @@ import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "@/componen
 import { DefaultSectionOpen } from "@/components/entity-browser/entity-browser-section"
 import { EntityBrowserContent } from "@/components/entity-browser/entity-browser-content"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
-import { usePanelRef } from "react-resizable-panels"
+import { useDefaultLayout, usePanelRef } from "react-resizable-panels"
 
 export function EntityBrowser() {
     const state = useEntityBrowserSettings()
@@ -40,6 +40,10 @@ export function EntityBrowser() {
     const structureBy = useEntityBrowserSettings((store) => store.structureBy)
     const setSortBy = useEntityBrowserSettings((store) => store.setSortBy)
     const setStructureBy = useEntityBrowserSettings((store) => store.setStructureBy)
+
+    const { defaultLayout, onLayoutChanged } = useDefaultLayout({
+        id: "entit-browser-property-overview"
+    })
 
     const collapseAllSections = useCallback(() => {
         setDefaultSectionOpen(false)
@@ -208,11 +212,18 @@ export function EntityBrowser() {
     ])
 
     return (
-        <ResizablePanelGroup orientation={"vertical"}>
+        <ResizablePanelGroup
+            orientation={"vertical"}
+            onLayoutChanged={onLayoutChanged}
+            defaultLayout={defaultLayout}
+        >
             <ResizablePanel defaultSize={"100%"} minSize={"200px"}>
                 {entityBrowserPanel}
             </ResizablePanel>
-            <ResizableHandle className="m-0.5" />
+            <ResizableHandle
+                disabled={!showPropertyOverview}
+                className={`${showPropertyOverview ? "" : "hidden"} m-0.5`}
+            />
             <ResizablePanel
                 defaultSize={"0%"}
                 minSize={"200px"}

--- a/components/nav/nav-drawer.tsx
+++ b/components/nav/nav-drawer.tsx
@@ -2,12 +2,16 @@ import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "@/componen
 import React, { PropsWithChildren, useEffect } from "react"
 import { ValidationDrawer } from "@/components/validation-drawer"
 import { useLayoutState } from "@/lib/state/layout-state"
-import { usePanelRef } from "react-resizable-panels"
+import { useDefaultLayout, usePanelRef } from "react-resizable-panels"
 
 export function NavDrawer({ children }: PropsWithChildren) {
     const showDrawer = useLayoutState((s) => s.showValidationDrawer)
     const setShowDrawer = useLayoutState((s) => s.setShowValidationDrawer)
     const ref = usePanelRef()
+
+    const { defaultLayout, onLayoutChanged } = useDefaultLayout({
+        id: "nav-drawer"
+    })
 
     useEffect(() => {
         if (!ref.current) return
@@ -19,8 +23,14 @@ export function NavDrawer({ children }: PropsWithChildren) {
     }, [ref, showDrawer])
 
     return (
-        <ResizablePanelGroup orientation={"vertical"}>
-            <ResizablePanel defaultSize={"100%"}>{children}</ResizablePanel>
+        <ResizablePanelGroup
+            orientation={"vertical"}
+            defaultLayout={defaultLayout}
+            onLayoutChanged={onLayoutChanged}
+        >
+            <ResizablePanel defaultSize={"100%"} minSize={"200px"}>
+                {children}
+            </ResizablePanel>
             <ResizableHandle className="m-0.5" />
             <ResizablePanel
                 collapsible

--- a/components/nav/nav-sidebar.tsx
+++ b/components/nav/nav-sidebar.tsx
@@ -27,7 +27,7 @@ import { usePersistence } from "@/components/providers/persistence-provider"
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "@/components/ui/resizable"
 import AIAssistantChat from "@/components/ai/chat"
 import { useLayoutState } from "@/lib/state/layout-state"
-import { usePanelRef } from "react-resizable-panels"
+import { useDefaultLayout, usePanelRef } from "react-resizable-panels"
 
 function NavSidebarButton({
     children,
@@ -93,6 +93,10 @@ export function NavSidebar({ children }: PropsWithChildren) {
 
     const ref = usePanelRef()
 
+    const { defaultLayout, onLayoutChanged } = useDefaultLayout({
+        id: "nav-sidebar-ai-assistant"
+    })
+
     useEffect(() => {
         if (!ref.current) return
         if (showAIAssistant) {
@@ -103,7 +107,11 @@ export function NavSidebar({ children }: PropsWithChildren) {
     }, [ref, showAIAssistant])
 
     return (
-        <ResizablePanelGroup orientation="horizontal">
+        <ResizablePanelGroup
+            orientation="horizontal"
+            defaultLayout={defaultLayout}
+            onLayoutChanged={onLayoutChanged}
+        >
             <ResizablePanel minSize={"50%"}>
                 <div className="grid grid-cols-[58px_auto] h-full">
                     <div className="relative h-full flex flex-col">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Panel sizes and layouts are now remembered across sessions in the entity browser, file explorer, navigation drawer, and AI assistant areas.
  * Added improved default sizing for resizable panels.
* **Bug Fixes**
  * The entity browser’s property overview resize handle is now hidden and disabled when that overview is turned off.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->